### PR TITLE
Move away from rules_jvm_external

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,23 @@ load("@rules_pmd//pmd:toolchains.bzl", "rules_pmd_toolchains")
 rules_pmd_toolchains()
 ```
 
+### Using a custom version of PMD
+
+Building on the default WORKSPACE configuration, you can use the `version` macro to define a custom PMD version to supply. 
+
+PMD bin releases are downloaded from [https://github.com/pmd/pmd/releases](https://github.com/pmd/pmd/releases).
+
+Example:
+
+```starlark
+
+load("@rules_pmd//pmd:dependencies.bzl", "rules_pmd_dependencies", "pmd_version")
+rules_pmd_dependencies(pmd_release = pmd_version(version = "6.44.0", sha256 = "7e6dceba88529a90b2b33c8f05b53bc409fa9eab79be592c875f6bd996aaade7"))
+
+load("@rules_pmd//pmd:toolchains.bzl", "rules_pmd_toolchains")
+rules_pmd_toolchains()
+```
+
 ### `BUILD` Configuration
 
 Once declared in the `WORSKPACE` file, the rule can be loaded in the `BUILD` file.

--- a/pmd/toolchains.bzl
+++ b/pmd/toolchains.bzl
@@ -4,30 +4,13 @@ See https://docs.bazel.build/versions/master/skylark/deploying.html#registering-
 """
 
 load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
-load("@rules_jvm_external//:defs.bzl", "maven_install")
-load("@rules_jvm_external//:specs.bzl", "maven")
 
-def rules_pmd_toolchains(pmd_version = "6.32.0"):
+def rules_pmd_toolchains():
     """Invokes `rules_pmd` toolchains.
 
     Declares toolchains that are dependencies of the `rules_pmd` workspace.
     Users should call this macro in their `WORKSPACE` file.
-
-    Args:
-        pmd_version: "net.sourceforge.pmd:pmd-dist" version used by rules.
     """
 
     rules_java_dependencies()
     rules_java_toolchains()
-
-    maven_install(
-        name = "rules_pmd_dependencies",
-        artifacts = [
-            maven.artifact("net.sourceforge.pmd", "pmd-core", pmd_version),
-            maven.artifact("net.sourceforge.pmd", "pmd-dist", pmd_version),
-        ],
-        repositories = [
-            "https://repo1.maven.org/maven2",
-            "https://repo.maven.apache.org/maven2/",
-        ],
-    )

--- a/pmd/wrapper/BUILD
+++ b/pmd/wrapper/BUILD
@@ -4,8 +4,7 @@ java_library(
     name = "wrapper",
     srcs = glob(["src/main/java/**/*.java"]),
     deps = [
-        "@rules_pmd_dependencies//:net_sourceforge_pmd_pmd_core",
-        "@rules_pmd_dependencies//:net_sourceforge_pmd_pmd_dist",
+        "@rules_pmd_dependencies//:net_sourceforge_pmd",
     ],
 )
 


### PR DESCRIPTION
`rules_jvm_external` adds quite a bit of overhead to our builds as it has to go fetch the unpinned maven dependency tree before it knows which jars to download for runtime. To avoid this overhead we can just download the bin releases directly from Github, which already contains the complete classpath that PMD needs to execute.

Alternatively we could move to pre-compiled releases, but that's going to bring quite a bit more overhead and maintenance costs into the rule set.

This pull request also updates the default PMD version to `6.44.0`.