### PR TITLE
Use non-deprecated run method

### DIFF
--- a/pmd/wrapper/src/main/java/io/buildfoundation/bazel/pmd/Main.java
+++ b/pmd/wrapper/src/main/java/io/buildfoundation/bazel/pmd/Main.java
@@ -14,13 +14,13 @@ import java.util.List;
 public final class Main {
 
     public static void main(String[] args) {
-        int result = PMD.run(args);
+        PMD.StatusCode result = PMD.runPmd(args);
 
-        if (result != 0) {
+        if (!result.equals(PMD.StatusCode.OK)) {
             printError(args);
         }
 
-        System.exit(result);
+        System.exit(result.toInt());
     }
 
     private static void printError(String[] args) {


### PR DESCRIPTION
- [run](https://github.com/pmd/pmd/blob/pmd_releases/6.50.0/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java#L434-L437) is marked as deprecated
- Make change to use [runPmd](https://github.com/pmd/pmd/blob/pmd_releases/6.50.0/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java#L439-L473)
- Update post-execution checks to use the integer value from the returned `StatusCode`