### PR TITLE
Fix argument names used in processing pmd-execution result

### DIFF
--- a/pmd/wrapper/src/main/java/io/buildfoundation/bazel/pmd/Main.java
+++ b/pmd/wrapper/src/main/java/io/buildfoundation/bazel/pmd/Main.java
@@ -26,8 +26,8 @@ public final class Main {
     private static void printError(String[] args) {
         List<String> arguments = Arrays.asList(args);
 
-        String reportFormat = argument(arguments, "-format");
-        String reportFilePath = argument(arguments, "-reportfile");
+        String reportFormat = argument(arguments, "--format");
+        String reportFilePath = argument(arguments, "--report-file");
 
         if (reportFormat != null && reportFilePath != null) {
             if (Arrays.asList(TextRenderer.NAME, TextColorRenderer.NAME, TextPadRenderer.NAME).contains(reportFormat)) {


### PR DESCRIPTION
- Fix arguments that are looked for when printing any errors to std-err
- [--format](https://github.com/buildfoundation/bazel_rules_pmd/blob/master/pmd/defs.bzl#L50) vs `-format`
- [--report-file](https://github.com/buildfoundation/bazel_rules_pmd/blob/master/pmd/defs.bzl#L51) vs `-reportFile`

**Context**
- The command-line options were [updated in pmd on 11/10/2021](https://github.com/pmd/pmd/commit/a71ca23285468c6e3bf3b9386ac8f1c38ebcebaf#diff-4c7258b727a31d566c79a2c4da2796175e3f2b9f97a1cbf482cf333b50ecedd5R123).
- The pmd-bazel-rule correctly defines and passes the parameter to the pmd-executable but we don't parse it correctly after the execution completes. [We updated the bazel-rule](https://github.com/buildfoundation/bazel_rules_pmd/pull/33/files#diff-c0aaf0c3f679572ba1bae6c742091bfa429f816b5339fa6f1bc98f35ea00f484R51) on 10/04/2022 to pass-in the new arguments but missed updating the arguments that are looked for when post-processing the results of the executable.